### PR TITLE
Have travis check python 2.7 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 sudo: false
 language: python
 python:
+  - "2.7"
   - "3.6"
 env:
   - TOXENV=flake8


### PR DESCRIPTION
It would be nice if this package was compatible with python 2.7 along with python 3.6.  Travis can automatically check this.