### PR TITLE
Renames function for compiling programs to `build`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ coaching effects from eight schools. For simplicity, we call this example
             'y': [28,  8, -3,  7, -1,  1, 18, 12],
             'sigma': [15, 10, 16, 11,  9, 11, 10, 18]}
 
-    posterior = pystan.compile(program_code, data=data)
+    posterior = pystan.build(program_code, data=data)
     fit = posterior.sample(num_chains=4, num_samples=1000)
     df = fit.to_frame()  # yields a pandas `DataFrame`
 

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -35,6 +35,6 @@ coaching effects from eight schools. For simplicity, we call this example
             'y': [28,  8, -3,  7, -1,  1, 18, 12],
             'sigma': [15, 10, 16, 11,  9, 11, 10, 18]}
 
-    posterior = pystan.compile(program_code, data=data)
+    posterior = pystan.build(program_code, data=data)
     fit = posterior.sample(num_chains=4, num_samples=1000)
     df = fit.to_frame()  # yields a pandas `DataFrame`

--- a/doc/source/library/index.rst
+++ b/doc/source/library/index.rst
@@ -10,7 +10,7 @@ Reference
 =========
 
 .. automodule:: pystan
-   :members: compile
+   :members: build
 
 .. automodule:: pystan.model
    :members: Model

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -1,6 +1,6 @@
 import pbr.version
 
-from pystan.model import compile  # noqa
+from pystan.model import build  # noqa
 
 
 __version__ = pbr.version.VersionInfo("pystan").version_string()

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -2,11 +2,11 @@ import concurrent.futures
 import json
 import typing
 
+import httpstan.models
+import httpstan.services.arguments as arguments
 import requests
 import tqdm
 
-import httpstan.models
-import httpstan.services.arguments as arguments
 import pystan.common
 import pystan.fit
 
@@ -14,7 +14,7 @@ import pystan.fit
 class Model:
     """Stores data associated with and proxies calls to a Stan model.
 
-    Returned by `compile`. Users will not instantiate this class directly.
+    Returned by `build`. Users will not instantiate this class directly.
 
     """
 
@@ -52,8 +52,8 @@ class Model:
         """
         assert isinstance(self.data, dict)
         assert "chain" not in kwargs, "`chain` id is set automatically."
-        assert "data" not in kwargs, "`data` is set in `compile`."
-        assert "random_seed" not in kwargs, "`random_seed` is set in `compile`."
+        assert "data" not in kwargs, "`data` is set in `build`."
+        assert "random_seed" not in kwargs, "`random_seed` is set in `build`."
         num_chains = kwargs.pop("num_chains", 1)
 
         with pystan.common.httpstan_server() as server:
@@ -126,8 +126,8 @@ class Model:
         )
 
 
-def compile(program_code, data=None, random_seed=None):
-    """Compile a Stan program.
+def build(program_code, data=None, random_seed=None):
+    """Build (compile) a Stan program.
 
     Arguments:
         program_code (str): Stan program code describing a Stan model.

--- a/tests/test_corr_matrix.py
+++ b/tests/test_corr_matrix.py
@@ -8,15 +8,15 @@ parameters {
 """
 
 
-def test_corr_matrix_compile():
+def test_corr_matrix_build():
     """Compile a simple model."""
-    posterior = pystan.compile(program_code)
+    posterior = pystan.build(program_code)
     assert posterior is not None
 
 
 def test_corr_matrix_sample():
     """Sample from a simple model."""
-    posterior = pystan.compile(program_code)
+    posterior = pystan.build(program_code)
     fit = posterior.sample(num_chains=2, num_samples=50)
     df = fit.to_frame()
     assert len(df["Lambda.1.1"]) == 100

--- a/tests/test_eight_schools.py
+++ b/tests/test_eight_schools.py
@@ -29,15 +29,15 @@ schools_data = {
 }
 
 
-def test_eight_schools_compile():
-    """Compile a simple model."""
-    posterior = pystan.compile(program_code, data=schools_data)
+def test_eight_schools_build():
+    """Build (compile) a simple model."""
+    posterior = pystan.build(program_code, data=schools_data)
     assert posterior is not None
 
 
 def test_eight_schools_sample():
     """Sample from a simple model."""
-    posterior = pystan.compile(program_code, data=schools_data)
+    posterior = pystan.build(program_code, data=schools_data)
     fit = posterior.sample(num_chains=1, num_samples=200, num_warmup=200)
     num_flat_params = schools_data["J"] * 2 + 2
     assert fit.values.shape == (1, 200, num_flat_params)

--- a/tests/test_matrix_params.py
+++ b/tests/test_matrix_params.py
@@ -11,14 +11,14 @@ def test_vector_params():
           beta ~ normal(0, 1);
         }
     """
-    posterior = pystan.compile(program_code, data={})
+    posterior = pystan.build(program_code)
     fit = posterior.sample()
     df = fit.to_frame()
     assert all(df.columns == ["beta.1", "beta.2", "beta.3"])
     assert len(df["beta.1"]) > 100
 
 
-def test_matrix_params_compile():
+def test_matrix_params_build():
     """Sample from a program with matrix-valued params."""
     program_code = """
         data {
@@ -35,7 +35,7 @@ def test_matrix_params_compile():
         }
     """
     data = {"K": 9, "D": 5}
-    posterior = pystan.compile(program_code, data=data)
+    posterior = pystan.build(program_code, data=data)
     assert posterior is not None
 
 
@@ -56,7 +56,7 @@ def test_matrix_params_sample():
         }
     """
     data = {"K": 9, "D": 5}
-    posterior = pystan.compile(program_code, data=data)
+    posterior = pystan.build(program_code, data=data)
     fit = posterior.sample()
     df = fit.to_frame()
     assert len(df.columns) == data["K"] * data["D"]

--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -1,17 +1,17 @@
 import pystan
 
 
-def test_normal_compile():
-    """Compile a simple model."""
+def test_normal_build():
+    """Build (compile) a simple model."""
     program_code = "parameters {real y;} model {y ~ normal(0,1);}"
-    posterior = pystan.compile(program_code, data={})
+    posterior = pystan.build(program_code)
     assert posterior is not None
 
 
 def test_normal_sample():
     """Sample from normal distribution."""
     program_code = "parameters {real y;} model {y ~ normal(0,1);}"
-    posterior = pystan.compile(program_code, data={})
+    posterior = pystan.build(program_code)
     assert posterior is not None
     fit = posterior.sample()
     assert fit.values.shape == (1, 1000, 1)  # 1 chain, n samples, 1 param
@@ -23,7 +23,7 @@ def test_normal_sample():
 def test_normal_sample_chains():
     """Sample from normal distribution with more than one chain."""
     program_code = "parameters {real y;} model {y ~ normal(0,1);}"
-    posterior = pystan.compile(program_code, data={})
+    posterior = pystan.build(program_code)
     assert posterior is not None
     fit = posterior.sample(num_chains=2)
     assert fit.values.shape == (2, 1000, 1)  # 1 chain, n samples, 1 param
@@ -33,9 +33,9 @@ def test_normal_sample_chains():
 
 
 def test_normal_sample_args():
-    """Sample from normal distribution with compile arguments."""
+    """Sample from normal distribution with build arguments."""
     program_code = "parameters {real y;} model {y ~ normal(0,1);}"
-    posterior = pystan.compile(program_code, data={}, random_seed=1)
+    posterior = pystan.build(program_code, random_seed=1)
     assert posterior is not None
     fit = posterior.sample(num_samples=350, num_thin=2)
     df = fit.to_frame()


### PR DESCRIPTION
Previous name was `compile`. New name is `build`. This name should be
more familiar to people who do not use compilers. RStan also plans
to use the verb `build`.

Closes #9