### PR TITLE
Add Fit class __getitem__

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,8 @@ coaching effects from eight schools. For simplicity, we call this example
 
     posterior = pystan.build(program_code, data=data)
     fit = posterior.sample(num_chains=4, num_samples=1000)
-    df = fit.to_frame()  # yields a pandas `DataFrame`
+    eta = fit["eta"]  # array with shape (8, 4000)
+    df = fit.to_frame()  # pandas `DataFrame`
 
 
 Installation

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -26,7 +26,7 @@ class Model:
         param_names: typing.Tuple[str],
         constrained_param_names: typing.Tuple[str],
         dims: typing.Tuple[typing.Tuple[int]],
-        random_seed: int,
+        random_seed: typing.Optional[int],
     ) -> None:
         if model_id != httpstan.models.calculate_model_id(program_code):
             raise ValueError("`model_id` does not match `program_code`.")
@@ -66,6 +66,8 @@ class Model:
                 payload.update(kwargs)
                 payload["chain"] = chain
                 payload["data"] = self.data
+                if self.random_seed is not None:
+                    payload["random_seed"] = self.random_seed
 
                 # fit needs to know num_samples, num_warmup, num_thin, save_warmup
                 # progress bar needs to know some of these

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pbr>=2.0 # Apache-2.0
-httpstan<1,>=0.3.2
+httpstan<1,>=0.4.0
 tqdm<5,>=4.14
 requests<3,>=2.18

--- a/tests/test_fit_basic_array.py
+++ b/tests/test_fit_basic_array.py
@@ -1,0 +1,47 @@
+"""Test model with array parameter."""
+import numpy as np
+import pytest
+
+import pystan
+
+program_code = """
+    data {
+      int<lower=2> K;
+    }
+    parameters {
+      real beta[K,1,2];
+    }
+    model {
+      for (k in 1:K)
+        beta[k,1,1] ~ normal(0,1);
+      for (k in 1:K)
+        beta[k,1,2] ~ normal(100,1);
+    }
+"""
+K = 4
+num_samples = 1000
+num_chains = 3
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return pystan.build(program_code, data={"K": K})
+
+
+@pytest.fixture(scope="module")
+def fit(posterior):
+    assert posterior is not None
+    return posterior.sample(num_samples=num_samples, num_chains=num_chains)
+
+
+def test_fit_array_draw_contents(fit):
+    """
+    Make sure shapes are getting unraveled correctly. Mixing up row-major and
+    column-major data is a potential issue.
+    """
+    beta = fit["beta"]
+    assert beta.shape == (K, 1, 2, num_samples * num_chains)
+    beta_mean = np.mean(beta, axis=-1)
+    assert beta_mean.shape == (K, 1, 2)
+    assert np.all(beta_mean[:, 0, 0] < 4)
+    assert np.all(beta_mean[:, 0, 1] > 99)

--- a/tests/test_fit_basic_matrix.py
+++ b/tests/test_fit_basic_matrix.py
@@ -1,0 +1,69 @@
+"""Test model with a matrix parameter."""
+import pytest
+
+import pystan
+
+# individual draw should look like:
+# [ 0 5 0 0 ]
+# [ 0 5 0 0 ]
+# [ 0 5 0 0 ]
+# in column-major order this is:
+# [ 0 0 0 5 5 5 0 0 0 0 0 0 ]
+
+program_code = """
+     data {
+       int<lower=2> K;
+       int<lower=1> D;
+     }
+     parameters {
+       matrix[K,D] beta;
+     }
+     model {
+     for (k in 1:K)
+         for (d in 1:D)
+           beta[k,d] ~ normal(if_else(d==2, 5, 0), 0.000001);
+     }
+"""
+K, D = 3, 4
+
+num_samples = 1000
+num_chains = 3
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return pystan.build(program_code, data={"K": K, "D": D})
+
+
+@pytest.fixture(scope="module")
+def fit(posterior):
+    assert posterior is not None
+    return posterior.sample(num_samples=num_samples, num_chains=num_chains)
+
+
+def test_fit_matrix_draw_order(fit):
+    assert fit is not None
+    assert fit._draws.shape == (K * D, num_samples, num_chains)
+    assert len(fit._draws[:, 0, 0]) == K * D
+    assert fit._parameter_indexes("beta") == tuple(range(K * D))
+
+
+def test_fit_matrix_draw_contents(fit):
+    assert fit is not None
+    assert fit._draws.shape == (K * D, num_samples, num_chains)
+    chain = fit._draws[:, :, 0]
+    # stored in column-major order
+    assert -1 < chain[0, :].mean() < 1
+    assert -1 < chain[1, :].mean() < 1
+    assert -1 < chain[2, :].mean() < 1
+    assert 4 < chain[3, :].mean() < 6
+    assert 4 < chain[4, :].mean() < 6
+    assert 4 < chain[5, :].mean() < 6
+    assert -1 < chain[6, :].mean() < 1
+    assert -1 < chain[7, :].mean() < 1
+    assert -1 < chain[8, :].mean() < 1
+    assert -1 < chain[9, :].mean() < 1
+    assert -1 < chain[10, :].mean() < 1
+    assert -1 < chain[11, :].mean() < 1
+    beta = fit["beta"]
+    assert beta.shape == (K, D, num_samples * num_chains)

--- a/tests/test_fit_basic_scalar.py
+++ b/tests/test_fit_basic_scalar.py
@@ -1,0 +1,34 @@
+"""Test model with a scalar parameter."""
+import numpy as np
+import pytest
+
+import pystan
+
+program_code = "parameters {real y;} model {y ~ normal(10, 0.0001);}"
+num_samples = 1000
+num_chains = 3
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return pystan.build(program_code)
+
+
+@pytest.fixture(scope="module")
+def fit(posterior):
+    assert posterior is not None
+    return posterior.sample(num_samples=num_samples, num_chains=num_chains)
+
+
+def test_fit_scalar_draw_order(fit):
+    # not much to test here
+    assert fit is not None
+    assert fit._draws.shape == (1, num_samples, num_chains)
+    assert len(fit._draws[:, 0, 0]) == 1
+    assert fit._parameter_indexes("y") == (0,)
+
+
+def test_fit_scalar_param(fit):
+    y = fit["y"]
+    assert y.shape == (1, num_samples * num_chains)
+    assert 9 < np.mean(y) < 11

--- a/tests/test_fit_basic_vector.py
+++ b/tests/test_fit_basic_vector.py
@@ -1,0 +1,53 @@
+"""Test model with a vector parameter."""
+import numpy as np
+import pytest
+
+import pystan
+
+# draws should look like (0, 5, 0)
+program_code = """
+parameters {
+  real beta[3];
+}
+model {
+  beta[1] ~ normal(0, 0.0001);
+  beta[2] ~ normal(5, 0.0001);
+  beta[3] ~ normal(0, 0.0001);
+}
+"""
+
+num_samples = 10
+num_chains = 2
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return pystan.build(program_code, random_seed=123)
+
+
+@pytest.fixture(scope="module")
+def fit(posterior):
+    assert posterior is not None
+    return posterior.sample(num_samples=num_samples, num_chains=num_chains)
+
+
+def test_fit_vector_draw_order(fit):
+    assert fit is not None
+    assert fit._draws.shape == (3, num_samples, num_chains)
+    assert len(fit._draws[:, 0, 0]) == 3
+    assert fit._parameter_indexes("beta") == tuple(range(3))
+
+
+def test_fit_vector_draw_contents(fit):
+    assert fit is not None
+    assert fit._draws.shape == (3, num_samples, num_chains)
+    chain = fit._draws[:, :, 0]
+    assert -1 < chain[0, :].mean() < 1
+    assert 4 < chain[1, :].mean() < 6
+    assert -1 < chain[2, :].mean() < 1
+    beta = fit["beta"]
+    assert beta.shape == (3, num_samples * num_chains)
+    beta_mean = np.mean(beta, axis=1)
+    assert -1 < beta_mean[0] < 1
+    assert 4 < beta_mean[1] < 6
+    assert -1 < beta_mean[2] < 1

--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -25,10 +25,10 @@ def test_normal_sample_chains():
     program_code = "parameters {real y;} model {y ~ normal(0,1);}"
     posterior = pystan.build(program_code)
     assert posterior is not None
-    fit = posterior.sample(num_chains=2)
-    assert fit.values.shape == (2, 1000, 1)  # 1 chain, n samples, 1 param
+    fit = posterior.sample(num_chains=3)
+    assert fit.values.shape == (1, 1000, 3)  # 1 param, n samples, 3 chains
     df = fit.to_frame()
-    assert len(df["y"]) == 2000
+    assert len(df["y"]) == 3000
     assert -5 < df["y"].mean() < 5
 
 


### PR DESCRIPTION
Allows users to get parameters via `__getitem__`. For example,
if a user has a Fit instance `fit` which has a matrix parameter `beta`
which has shape (3, 2) in Stan, `fit["beta"]` returns an array
with shape (3, 2, num_samples * num_chains).

This commit changes the shape of the array which is used to store
draws internally.