### PR TITLE
fix: increase required httpstan version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pbr<5,>=4.0 # Apache-2.0
-httpstan<1,>=0.7.2
+httpstan<1,>=0.7.5
 tqdm<5,>=4.14
 requests<3,>=2.18


### PR DESCRIPTION
httpstan versions earlier than 0.7.5 have problematic binary wheels.