### PR TITLE
feat: `Model` accepts a wider range of data

### DIFF
--- a/tests/test_data_validation.py
+++ b/tests/test_data_validation.py
@@ -1,0 +1,35 @@
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import stan.model
+
+
+def test_ensure_json():
+    data = {"K": 3}
+    assert stan.model._ensure_json_serializable(data) == data
+    data = {"K": 3, "x": [3, 4, 5]}
+    assert stan.model._ensure_json_serializable(data) == data
+
+    class DummyClass:
+        pass
+
+    data = {"K": DummyClass(), "x": [3, 4, 5]}
+    with pytest.raises(TypeError, match=r"Value associated with variable `K`"):
+        stan.model._ensure_json_serializable(data)
+
+
+def test_ensure_json_numpy():
+    data = {"K": 3, "x": np.array([3, 4, 5])}
+    expected = {"K": 3, "x": [3, 4, 5]}
+    assert stan.model._ensure_json_serializable(data) == expected
+    assert json.dumps(stan.model._ensure_json_serializable(data))
+
+
+def test_ensure_json_pandas():
+    data = {"K": 3, "x": pd.Series([3, 4, 5])}
+    expected = {"K": 3, "x": [3, 4, 5]}
+    assert stan.model._ensure_json_serializable(data) == expected
+    assert json.dumps(stan.model._ensure_json_serializable(data))

--- a/tests/test_eight_schools.py
+++ b/tests/test_eight_schools.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 import stan
@@ -39,6 +41,17 @@ def posterior():
 def test_eight_schools_build(posterior):
     """Verify eight schools compiles."""
     assert posterior is not None
+
+
+def test_eight_schools_build_numpy(posterior):
+    """Verify eight schools compiles."""
+    schools_data_alt = {
+        "J": 8,
+        "y": np.array([28, 8, -3, 7, -1, 1, 18, 12]),
+        "sigma": pd.Series([15, 10, 16, 11, 9, 11, 10, 18], name="sigma"),
+    }
+    posterior_alt = stan.build(program_code, data=schools_data_alt)
+    assert posterior_alt is not None
 
 
 def test_eight_schools_sample(posterior):


### PR DESCRIPTION
Values which resemble Numpy `ndarray` and pandas `Series` should be
accepted. They will be converted into (JSON-serializable) lists.

Closes #51