### PR TITLE
docs: Remove changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,0 @@
-Changelog
----------
-
-3.0.0a11 (24 Apr 2020)
-++++++++++++++++++++++
-- Add support for user-provided initial values

--- a/doc/source/release-howto.rst
+++ b/doc/source/release-howto.rst
@@ -12,7 +12,6 @@ How to make a release
 =====================
 
 - Verify that the correct version is shown in ``pyproject.toml`` and ``stan/__init__.py``.
-- Update ``CHANGELOG.rst``. Create Pull Request. Wait for PR to be merged.
 - Tag (with signature): ``git tag -u CB808C34B3BFFD03EFD2751597A78E5BFA431C9A -s 1.2.3``, replacing ``1.2.3`` with the version.
 - Push the new tag to the repository: ``git push origin 1.2.3``, replacing ``origin`` with the remote and ``1.2.3`` with the version.
 - Publish (universal) wheel using ``poetry``. [TODO: add details]


### PR DESCRIPTION
The changelog will be automatically generated from commit messages in
the future. Updating it manually is a conspicuous waste of developer time.