### PR TITLE
feat: Use async http requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ python = "^3.7"
 aiohttp = "^3.6"
 httpstan = "^1.0"
 tqdm = "^4.14"
-requests = "^2.18"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"

--- a/tests/test_httpstan_health.py
+++ b/tests/test_httpstan_health.py
@@ -1,10 +1,11 @@
-import requests
+import pytest
+import aiohttp
 
 import stan
 
 
-def test_httpstan_health():
-    with stan.common.httpstan_server() as server:
-        host, port = server.host, server.port
-        response = requests.get(f"http://{host}:{port}/v1/health")
-        assert response.status_code == 200
+@pytest.mark.asyncio
+async def test_httpstan_health():
+    async with stan.common.httpstan_server() as (host, port):
+        async with aiohttp.request("GET", f"http://{host}:{port}/v1/health") as resp:
+            assert resp.status == 200

--- a/tests/test_httpstan_unused_port.py
+++ b/tests/test_httpstan_unused_port.py
@@ -1,18 +1,19 @@
 import socket
 
-import requests
+import aiohttp
+import pytest
 
 import stan
 
 
-def test_httpstan_port_conflict():
+@pytest.mark.asyncio
+async def test_httpstan_port_conflict():
     s = socket.socket()
     try:
         s.bind(("", 8080))
-        with stan.common.httpstan_server() as server:
-            host, port = server.host, server.port
-            response = requests.get(f"http://{host}:{port}/v1/health")
-            assert response.status_code == 200
-            assert port != 8080
+        async with stan.common.httpstan_server() as (host, port):
+            async with aiohttp.request("GET", f"http://{host}:{port}/v1/health") as resp:
+                assert resp.status == 200
+                assert port != 8080
     finally:
         s.close()


### PR DESCRIPTION
Avoids creating a new thread and eliminates dependency on `requests`.
Uses aiohttp, which we already have thanks to the dependency on `httpstan`.
