### PR TITLE
Update PyStan to work with httpstan 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pystan"
-version = "3.0.0a12"
+version = "3.0.0-beta.0"
 description = "Python interface to Stan, a package for Bayesian inference"
 authors = [
   "Allen Riddell <riddella@indiana.edu>",
@@ -23,7 +23,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.6"
-httpstan = "^1.0"
+httpstan = "^2.0.2"
 tqdm = "^4.14"
 requests = "^2.18"
 
@@ -37,3 +37,10 @@ build-backend = "poetry.masonry.api"
 
 [tool.black]
 line-length = 119
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ python = "^3.7"
 aiohttp = "^3.6"
 httpstan = "^2.0.2"
 tqdm = "^4.14"
-requests = "^2.18"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"

--- a/tests/test_basic_bernoulli.py
+++ b/tests/test_basic_bernoulli.py
@@ -31,13 +31,6 @@ def fit(posterior):
     return posterior.sample(num_chains=4)
 
 
-def test_bernoulli_sampling_error():
-    bad_data = data.copy()
-    del bad_data["N"]
-    with pytest.raises(RuntimeError, match=r"variable does not exist"):
-        stan.build(program_code, data=bad_data)
-
-
 def test_bernoulli_sampling_thin(posterior):
     fit = posterior.sample(num_thin=2)
     assert fit.values.shape[1] == 500

--- a/tests/test_build_program.py
+++ b/tests/test_build_program.py
@@ -14,13 +14,13 @@ def test_build_basic():
 
 def test_stanc_no_such_distribution():
     program_code = "parameters {real z;} model {z ~ no_such_distribution();}"
-    with pytest.raises(RuntimeError, match=r"Probability function must end in _lpdf or _lpmf\. Found"):
+    with pytest.raises(RuntimeError, match=r"Semantic error in"):
         stan.build(program_code=program_code)
 
 
 def test_stanc_invalid_assignment():
     program_code = "parameters {real z;} model {z = 3;}"
-    with pytest.raises(RuntimeError, match=r"Cannot assign to variable outside of declaration block"):
+    with pytest.raises(RuntimeError, match=r"Semantic error in"):
         stan.build(program_code=program_code)
 
 
@@ -34,5 +34,5 @@ def test_stanc_exception_semicolon():
         z ~ normal(0, 1);
         y ~ normal(0, 1);}
     """
-    with pytest.raises(RuntimeError, match=r'PARSER EXPECTED: ";"'):
+    with pytest.raises(RuntimeError, match=r"Syntax error in"):
         stan.build(program_code=program_code)

--- a/tests/test_httpstan_health.py
+++ b/tests/test_httpstan_health.py
@@ -1,10 +1,11 @@
-import requests
+import pytest
+import aiohttp
 
 import stan
 
 
-def test_httpstan_health():
-    with stan.common.httpstan_server() as server:
-        host, port = server.host, server.port
-        response = requests.get(f"http://{host}:{port}/v1/health")
-        assert response.status_code == 200
+@pytest.mark.asyncio
+async def test_httpstan_health():
+    async with stan.common.httpstan_server() as (host, port):
+        async with aiohttp.request("GET", f"http://{host}:{port}/v1/health") as resp:
+            assert resp.status == 200

--- a/tests/test_httpstan_unused_port.py
+++ b/tests/test_httpstan_unused_port.py
@@ -1,18 +1,19 @@
 import socket
 
-import requests
+import aiohttp
+import pytest
 
 import stan
 
 
-def test_httpstan_port_conflict():
+@pytest.mark.asyncio
+async def test_httpstan_port_conflict():
     s = socket.socket()
     try:
         s.bind(("", 8080))
-        with stan.common.httpstan_server() as server:
-            host, port = server.host, server.port
-            response = requests.get(f"http://{host}:{port}/v1/health")
-            assert response.status_code == 200
-            assert port != 8080
+        async with stan.common.httpstan_server() as (host, port):
+            async with aiohttp.request("GET", f"http://{host}:{port}/v1/health") as resp:
+                assert resp.status == 200
+                assert port != 8080
     finally:
         s.close()

--- a/tests/test_model_build_data.py
+++ b/tests/test_model_build_data.py
@@ -29,16 +29,6 @@ def posterior():
     return stan.build(program_code, data=data)
 
 
-def test_data_wrong_dtype(posterior):
-    # pull in posterior to cache compilation
-    bad_data = copy.deepcopy(data)
-    # float is wrong dtype
-    bad_data["y"] = np.array(bad_data["y"], dtype=float)
-    assert bad_data["y"].dtype == float
-    with pytest.raises(RuntimeError, match=r"int variable contained non-int values"):
-        stan.build(program_code, data=bad_data)
-
-
 def test_data_unmodified(posterior):
     # pull in posterior to cache compilation
     data_with_array = copy.deepcopy(data)


### PR DESCRIPTION
The commit messages have specific details. There are two major changes to align things with httpstan:
- Use async http requests instead of `requests`. This is what httpstan has always done in its tests.
- Remove two tests which are failing due to the shift from "stanc2" to stanc3.