### PR TITLE
fix: Provide __version__ via importlib

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 version: ~> 1.0
 language: python
-python: 3.7
+python: 3.8
 os: linux
 dist: bionic
 jobs:
@@ -12,5 +12,8 @@ before_install:
 install:
   - pip install "poetry<2,>=1.0" tox
 script:
-  - tox
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION != "3.7" ]]; then
+      tox
+    fi
   - poetry install -v && poetry run pytest -s -v tests

--- a/stan/__init__.py
+++ b/stan/__init__.py
@@ -1,3 +1,8 @@
 from stan.model import build  # noqa
 
-__version__ = "3.0.0-beta.1"
+try:
+    from importlib.metadata import version
+
+    __version__ = version("pystan")
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
It is easy to forget to update the version string
in the `__init__.py` file. With this change the
version is stored in a single place (`pyproject.toml`).