### PR TITLE
fix: Add missing numpy requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 python = "^3.7"
 aiohttp = "^3.6"
 httpstan = "^2.0.2"
+numpy = "^1.7"
 tqdm = "^4.14"
 
 # docs


### PR DESCRIPTION
numpy is obviously a requirement. Everything works without
this requirement because `httpstan` requires numpy. We
cannot assume that this will always be the case.