### PR TITLE
test: Align testing packages with httpstan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ sphinx = { version = "^3.1.1", optional = true }
 sphinx-rtd-theme = { version = "^0.5", optional = true }
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.4"
+pytest-cov = "^2.8"
+pytest-asyncio = "^0.10"
 pandas = "^1.0"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Fixes #123

This PR fixes the missing `pytest.marker.asyncio` by installing `pytest-asyncio`.  `pytest` installation replaced with `pytest-cov`.

Packages are updated to be aligned with httpstan.