### PR TITLE
feat: Provide user feedback during compilation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ python = "^3.7"
 aiohttp = "^3.6"
 httpstan = "^2.0.2"
 numpy = "^1.7"
-tqdm = "^4.14"
+clikit = "^0.6.2"
 
 # docs
 sphinx = { version = "^3.1.1", optional = true }


### PR DESCRIPTION
Compiling the Stan program takes time. Give the user some indication of
what is happening.

Note that we cannot use a progress indicator here because httpstan
redirects everything sent to stderr to /dev/null to avoid overwhelming
the user with a flood of compiler info and warning messages. Progress
indicators can be used elsewhere.

Closes #111