### PR TITLE
feat: Show non-fatal logger messages to use

### DIFF
--- a/tests/test_logger_messages.py
+++ b/tests/test_logger_messages.py
@@ -1,0 +1,22 @@
+import io
+import contextlib
+
+import pytest
+
+import stan
+
+# program code designed to generate initialization failed messages
+program_code = "parameters { real y; } model { y ~ uniform(1.9, 2); }" ""
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return stan.build(program_code, random_seed=1)
+
+
+def test_logger_messages_present(posterior):
+    f = io.StringIO()
+    with contextlib.redirect_stderr(f):
+        posterior.sample()
+    s = f.getvalue()
+    assert "Rejecting initial value:" in s

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ commands = mypy --strict-optional --ignore-missing-imports --follow-imports=skip
 show-source = True
 max-line-length = 119
 select = C,E,F,W,B
-ignore = E501,E203
+ignore = E501,E203,W503
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build


### PR DESCRIPTION
Show non-fatal info and warning messages to user.
Previously logger messages would only be displayed if
sampling aborted.

Closes #69