### PR TITLE
ci: Publish wheel to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,23 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - "*.*.*"
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry==1.0.10
+      - name: Build and publish
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python -m poetry publish --build -u __token__ -p $PYPI_TOKEN -r testpypi


### PR DESCRIPTION
Publish wheel to PyPI. Only publish if the commit is tagged.  Uses
Github Actions.

This particular commit only enables uploading to Test PyPI. If
everything works, an additional commit can switch over to the real
thing.

Closes #89