### PR TITLE
fix: Use pytest 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ sphinx = { version = "^3.1.1", optional = true }
 sphinx-rtd-theme = { version = "^0.5", optional = true }
 
 [tool.poetry.dev-dependencies]
+pytest = "^5.4"
 pytest-cov = "^2.8"
 pytest-asyncio = "^0.10"
 pandas = "^1.0"


### PR DESCRIPTION
Use pytest 5.x, not pytest 6.x.
Tests have not been updated for pytest 6.x.

Closes #148