### PR TITLE
ci: Enable github actions publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,4 +20,4 @@ jobs:
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python -m poetry publish --build -u __token__ -p $PYPI_TOKEN -r testpypi
+          python -m poetry publish --build -u __token__ -p $PYPI_TOKEN


### PR DESCRIPTION
For future reference, to upload to testpypi with poetry one
needs to first issue the following poetry command:
poetry config repositories.testpypi https://test.pypi.org/legacy/