### PR TITLE
fix: Make changes required by httpstan 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.6"
-httpstan = "^3.0.0"
+httpstan = "^4.0"
+pysimdjson = "^3.1"
 numpy = "^1.7"
 clikit = "^0.6.2"
 

--- a/stan/model.py
+++ b/stan/model.py
@@ -195,6 +195,10 @@ class Model:
                 for stan_output in stan_outputs:
                     assert isinstance(stan_output, bytes)
                     for line in stan_output.splitlines():
+                        # Do not attempt to parse non-logger messages. Draws could contain nan or inf values.
+                        # simdjson cannot parse lines containing such values.
+                        if b'"logger"' not in line:
+                            continue
                         msg = parser.parse(line)
                         if is_nonempty_logger_message(msg) and not is_iteration_or_elapsed_time_logger_message(msg):
                             nonstandard_logger_messages.append(msg.as_dict())

--- a/tests/test_nan_inf.py
+++ b/tests/test_nan_inf.py
@@ -1,0 +1,30 @@
+"""Test serialization of nan and inf values."""
+import math
+
+import stan
+
+program_code = """
+    parameters {
+      real eta;
+    }
+    transformed parameters {
+      real alpha;
+      real beta;
+      real gamma;
+      alpha = not_a_number();
+      beta = positive_infinity();
+      gamma = negative_infinity();
+    }
+    model {
+      target += normal_lpdf(eta | 0, 1);
+    }
+"""
+
+
+def test_nan_inf():
+    posterior = stan.build(program_code)
+    fit = posterior.sample()
+    assert fit is not None
+    assert math.isnan(fit["alpha"].ravel()[0])
+    assert math.isinf(fit["beta"].ravel()[0])
+    assert math.isinf(fit["gamma"].ravel()[0])


### PR DESCRIPTION
Make changes required by new version of httpstan. httpstan 4.0
uses JSON instead of Protocol Buffers.