### PR TITLE
tests: fix flaky cache tests

### DIFF
--- a/tests/test_fit_cache.py
+++ b/tests/test_fit_cache.py
@@ -1,10 +1,11 @@
 """Tests related to cached fits."""
-import shutil
+import os
 import pathlib
 import random
 
-import stan
 import httpstan.cache
+
+import stan
 
 program_code = "parameters {real y;} model {y ~ normal(0,1);}"
 
@@ -13,33 +14,38 @@ def cache_path():
     return pathlib.Path(httpstan.cache.model_directory("models/abcdef")).parent
 
 
+def file_usage(path):
+    """Calculate the size used by the files in bytes."""
+    size = 0
+    for root, _, files in os.walk(path):
+        for filename in files:
+            size += os.stat(os.path.join(root, filename)).st_size
+    return size
+
+
 def test_fit_cache():
     """Test that a fit with a random seed set is cached."""
 
-    cache_size_before = shutil.disk_usage(cache_path()).used
-    print(cache_size_before)
+    cache_size_before = file_usage(cache_path())
     # this fit is cacheable
     random_seed = random.randrange(1, 2 ** 16)
     normal_posterior = stan.build(program_code, random_seed=random_seed)
     normal_posterior.sample()
-    cache_size_after = shutil.disk_usage(cache_path()).used
-    print(cache_size_after)
+    cache_size_after = file_usage(cache_path())
     assert cache_size_after > cache_size_before
 
     # fit is now in cache
-    cache_size_before = shutil.disk_usage(cache_path()).used
+    cache_size_before = file_usage(cache_path())
     normal_posterior.sample()
-    cache_size_after = shutil.disk_usage(cache_path()).used
-    # allow for a 4096 byte difference (an empty directory takes 4K)
-    assert abs(cache_size_before - cache_size_after) <= 4096
+    cache_size_after = file_usage(cache_path())
+    assert cache_size_before == cache_size_after
 
 
 def test_fit_cache_uncacheable():
     """Test that a fit with a random seed set is cached."""
-    cache_size_before = shutil.disk_usage(cache_path()).used
+    cache_size_before = file_usage(cache_path())
     # this fit is NOT cacheable, should not be saved
     normal_posterior = stan.build(program_code)
     normal_posterior.sample()
-    cache_size_after = shutil.disk_usage(cache_path()).used
-    # allow for empty directories (4096 bytes on Linux) and other chance file creations.
-    assert abs(cache_size_before - cache_size_after) <= 16384
+    cache_size_after = file_usage(cache_path())
+    assert cache_size_before == cache_size_after


### PR DESCRIPTION
Fixes #179 

Change shutil.disk_usage to combination of os.walk and os.stat to calculate the sum of filesizes.

This PR adds a helper function `file_usage` which calculates bytes used by the files. If used path doesn't exists this function returns 0.

```python
def file_usage(path):
    """Calculate the size used by the files in bytes."""
    size = 0
    for root, _, files in os.walk(path):
        for filename in files:
            size += os.stat(os.path.join(root, filename)).st_size
    return size
```