### PR TITLE
ci: Set CI job timeout to 20 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   tests:
     name: pystan tests
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.14]


### PR DESCRIPTION
Set CI job timeout to 20 minutes. Most jobs
finish in about 10 minutes.

Closes #181