### PR TITLE
feat: Add constrain_pars method to Model

### DIFF
--- a/tests/test_constrain_pars.py
+++ b/tests/test_constrain_pars.py
@@ -1,0 +1,39 @@
+"""Test constrain parameters."""
+import random
+
+import numpy as np
+import pytest
+
+import stan
+
+program_code = """
+parameters {
+  real x;
+  real<lower=0> y;
+}
+transformed parameters {
+    real x_mult = x * 2;
+}
+generated quantities {
+    real z = x + y;
+}
+"""
+num_samples = 1000
+num_chains = 4
+x = random.uniform(0, 10)
+y = random.uniform(0, 10)
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return stan.build(program_code, random_seed=1)
+
+
+@pytest.mark.parametrize("x", [x])
+@pytest.mark.parametrize("y", [y])
+def test_log_prob(posterior, x: float, y: float):
+    constrained_params = posterior.constrain_pars([x, y])
+    assert np.allclose(x, constrained_params[0])
+    assert np.allclose(np.exp(y), constrained_params[1])
+    assert np.allclose(x * 2, constrained_params[2])
+    assert np.allclose(x + np.exp(y), constrained_params[3])

--- a/tests/test_eight_schools.py
+++ b/tests/test_eight_schools.py
@@ -59,7 +59,11 @@ def test_eight_schools_sample(posterior):
     num_chains, num_samples = 2, 200
     fit = posterior.sample(num_chains=num_chains, num_samples=num_samples, num_warmup=num_samples)
     num_flat_params = schools_data["J"] * 2 + 2
-    assert fit.values.shape == (len(fit.sample_and_sampler_param_names) + num_flat_params, num_samples, num_chains,)
+    assert fit.values.shape == (
+        len(fit.sample_and_sampler_param_names) + num_flat_params,
+        num_samples,
+        num_chains,
+    )
     df = fit.to_frame()
     assert "eta.1" in df.columns
     assert len(df["eta.1"]) == num_samples * num_chains

--- a/tests/test_eight_schools_large.py
+++ b/tests/test_eight_schools_large.py
@@ -45,7 +45,11 @@ def test_eight_schools_large_sample(posterior):
     num_chains, num_samples = 2, 200
     fit = posterior.sample(num_chains=num_chains, num_samples=num_samples, num_warmup=num_samples)
     num_flat_params = schools_data["J"] * 2 + 2
-    assert fit.values.shape == (len(fit.sample_and_sampler_param_names) + num_flat_params, num_samples, num_chains,)
+    assert fit.values.shape == (
+        len(fit.sample_and_sampler_param_names) + num_flat_params,
+        num_samples,
+        num_chains,
+    )
     df = fit.to_frame()
     assert "eta.1" in df.columns
     assert len(df["eta.1"]) == num_samples * num_chains


### PR DESCRIPTION
Add constrain_pars method to Model instances: this
method transforms a sequence of unconstrained parameters
to their defined support, optinally including transformed
parameters and generated quantities.