### PR TITLE
feat: Add unconstrain_pars to Model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 aiohttp = "^3.6"
-httpstan = "^4.0"
+httpstan = "^4.2.1"
 pysimdjson = "^3.1"
 numpy = "^1.7"
 clikit = "^0.6.2"

--- a/tests/test_unconstrain_pars.py
+++ b/tests/test_unconstrain_pars.py
@@ -1,0 +1,43 @@
+"""Test constrain parameters."""
+import random
+
+import numpy as np
+import pytest
+
+import stan
+
+program_code = """
+parameters {
+  real x;
+  real<lower=0> y;
+}
+transformed parameters {
+    real x_mult = x * 2;
+}
+generated quantities {
+    real z = x + y;
+}
+"""
+num_samples = 1000
+num_chains = 4
+x = random.uniform(0, 10)
+y = random.uniform(0, 10)
+
+
+@pytest.fixture(scope="module")
+def posterior():
+    return stan.build(program_code, random_seed=1)
+
+
+@pytest.mark.parametrize("x", [x])
+@pytest.mark.parametrize("y", [y])
+def test_log_prob(posterior, x: float, y: float):
+    constrained_params = posterior.constrain_pars([x, y])
+    constrained_pars = {
+        "x": constrained_params[0],
+        "y": constrained_params[1],
+        "x_mult": constrained_params[2],
+        "z": constrained_params[3],
+    }
+    unconstrained_params = posterior.unconstrain_pars(constrained_pars)
+    assert np.allclose([x, y], unconstrained_params)


### PR DESCRIPTION
Add unconstrain_pars method to Model instances: this
method transforms a sequence of constrained parameters
from their defined support to unconstrained space.