### PR TITLE
docs: Mention PyStan-specific `num_chains` kwarg

### DIFF
--- a/stan/model.py
+++ b/stan/model.py
@@ -87,6 +87,10 @@ class Model:
         See the CmdStan documentation for parameter descriptions and default
         values.
 
+        `num_chains` is the lone PyStan-specific keyword argument. It indicates
+        the number of independent processes to use when drawing samples.
+        The default value is 1.
+
         Returns:
             Fit: instance of Fit allowing access to draws.
 


### PR DESCRIPTION
Mention the PyStan-specific `num_chains` keyword argument. This
is the only PyStan-specific argument. All other keyword arguments
are passed to the stan::services function.

Closes #112