### PR TITLE
docs: set version correctly in development

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,11 @@ intersphinx_mapping = {
     "python": ("http://python.readthedocs.io/en/latest/", None),
 }
 
-version = release = stan.__version__
+try:
+    version = release = stan.__version__
+except AttributeError:
+    # install the package to make `stan.__version__` available
+    version = release = "unknown-dev"
 
 ################################################################################
 # theme configuration


### PR DESCRIPTION
Give sphinx a package version during development.
Previously sphinx would try to retrieve `stan.__version__`.
This is not available when the package is not installed.
(We use `importlib.metadata.version`)

Fixes exception which occurs when running `script/check`
during development.