### PR TITLE
fix: add a scripts/test script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,4 +39,4 @@ jobs:
         run: scripts/check
 
       - name: Run tests
-        run: python -m pytest -s -v tests
+        run: scripts/test

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+set -x
+python3 -m pytest -s -v tests


### PR DESCRIPTION
Add a scripts/test script to make clearer how we test the
package. Previously the invocation of pytest was
only "documented" in our CI configuration. Now
it is "documented" in the repository proper in the form of a script.
With luck, anyone thinking to run `scripts/check` will
notice `scripts/test`.