### PR TITLE
Add option to keep chains unflattened.

### DIFF
--- a/tests/test_fit_basic_array.py
+++ b/tests/test_fit_basic_array.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 import stan
+import stan.fit
 
 program_code = """
     data {
@@ -34,7 +35,7 @@ def fit(posterior):
     return posterior.sample(num_samples=num_samples, num_chains=num_chains)
 
 
-def test_fit_array_draw_contents(fit):
+def test_fit_array_draw_contents(fit: stan.fit.Fit):
     """
     Make sure shapes are getting unraveled correctly. Mixing up row-major and
     column-major data is a potential issue.
@@ -45,3 +46,5 @@ def test_fit_array_draw_contents(fit):
     assert beta_mean.shape == (K, 1, 2)
     assert np.all(beta_mean[:, 0, 0] < 4)
     assert np.all(beta_mean[:, 0, 1] > 99)
+
+    assert fit.get_samples("beta", flatten_chains=False).shape == (K, 1, 2, num_samples, num_chains)

--- a/tests/test_fit_basic_matrix.py
+++ b/tests/test_fit_basic_matrix.py
@@ -2,6 +2,7 @@
 import pytest
 
 import stan
+import stan.fit
 
 # individual draw should look like:
 # [ 0 5 0 0 ]
@@ -49,7 +50,7 @@ def test_fit_matrix_draw_order(fit):
     assert fit._parameter_indexes("beta") == tuple(offset + i for i in range(K * D))
 
 
-def test_fit_matrix_draw_contents(fit):
+def test_fit_matrix_draw_contents(fit: stan.fit.Fit):
     assert fit is not None
     offset = len(fit.sample_and_sampler_param_names)
     assert fit._draws.shape == (offset + K * D, num_samples, num_chains)
@@ -69,3 +70,5 @@ def test_fit_matrix_draw_contents(fit):
     assert -1 < chain[offset + 11, :].mean() < 1
     beta = fit["beta"]
     assert beta.shape == (K, D, num_samples * num_chains)
+
+    fit.get_samples("beta", flatten_chains=False).shape == (K, D, num_samples, num_chains)

--- a/tests/test_fit_basic_vector.py
+++ b/tests/test_fit_basic_vector.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 import stan
+import stan.fit
 
 # draws should look like (0, 5, 0)
 program_code = """
@@ -39,7 +40,7 @@ def test_fit_vector_draw_order(fit):
     assert fit._parameter_indexes("beta") == tuple(offset + i for i in range(3))
 
 
-def test_fit_vector_draw_contents(fit):
+def test_fit_vector_draw_contents(fit: stan.fit.Fit):
     assert fit is not None
     offset = len(fit.sample_and_sampler_param_names)
     assert fit._draws.shape == (offset + 3, num_samples, num_chains)
@@ -53,3 +54,5 @@ def test_fit_vector_draw_contents(fit):
     assert -1 < beta_mean[0] < 1
     assert 4 < beta_mean[1] < 6
     assert -1 < beta_mean[2] < 1
+
+    fit.get_samples("beta", flatten_chains=False).shape == (3, num_samples, num_chains)

--- a/tests/test_fit_shape.py
+++ b/tests/test_fit_shape.py
@@ -103,5 +103,6 @@ def test_fit_empty_array_shape(zero_dims):
     data = get_data(zero_dims)
     fit = get_fit(data)
     for parameter, dim in dims.items():
-        shape = tuple(map(data.get, dim)) + (num_samples * num_chains,)
-        assert fit[parameter].shape == shape
+        base_shape = tuple(map(data.get, dim))
+        assert fit[parameter].shape == base_shape + (num_samples * num_chains,)
+        assert fit.get_samples(parameter, flatten_chains=False).shape == base_shape + (num_samples, num_chains)

--- a/tests/test_matrix_params.py
+++ b/tests/test_matrix_params.py
@@ -59,5 +59,5 @@ def test_matrix_params_sample():
     posterior = stan.build(program_code, data=data)
     fit = posterior.sample()
     df = fit.to_frame()
-    assert len(df.columns) == len(fit.sample_and_sampler_param_names) + data["K"] * data["D"]
+    assert len(df.columns) == len(fit.sample_and_sampler_param_names) + 1 + data["K"] * data["D"]
     assert len(df["beta.1.1"]) > 100


### PR DESCRIPTION
This PR

- adds a function `get_samples(param: str, flatten_chains: bool = True) -> np.ndarray` to the `Fit` object which reproduces the behaviour of `__getitem__` by default. However, setting `flatten_chains=False` leaves the trailing dimension as `(num_saved_samples, num_chains)`. This behaviour is useful for comparing initialisations of different chains, computing Rhat, etc.
- adds a `chain__` column to the data frame produced by `Fit.to_frame` which can be used to identify which chain generated a given sample.