### PR TITLE
ci: Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,6 @@ sphinx:
 
 python:
   install:
+    - requirements: docs-requirements.txt
     - method: pip
       path: .
-      extra_requirements:
-        - docs

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,5 @@
+# docs requirements
+# these requirements are used by the documentation builder
+
+sphinx~=4.2 # BSD
+sphinx-rtd-theme~=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ mypy = "0.961"
 types-setuptools = "^57.4"
 flake8 = "^4.0"
 # documentation
-sphinx = "^5.0"
+# NOTE: when changing these, update docs-requirements.txt
+sphinx = "^4.2"
 sphinx-rtd-theme = "^1.0"
 
 [tool.black]


### PR DESCRIPTION
Mirrors the approach used by httpstan. On readthedocs build machines we
first install the packages in `docs-requirements.txt` and then install
the pystan package (bringing in all the normal requirements). Then we
build the docs.