### PR TITLE
CI: Add Python 3.13 and 3.14 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        include:
-          - {runs-on: ubuntu-24.04, python-version: "3.10"}
-          - {runs-on: ubuntu-24.04, python-version: "3.11"}
-          - {runs-on: ubuntu-24.04, python-version: "3.12"}
-          - {runs-on: macos-13, python-version: "3.10"}
-          - {runs-on: macos-13, python-version: "3.11"}
-          - {runs-on: macos-13, python-version: "3.12"}
+        runs-on: [ubuntu-24.04, macos-13]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Add Python 3.13 and 3.14 to the test matrix of the main GitHub Actions workflow.